### PR TITLE
Re-enabled internet_access_enabled, tested on UDM Pro (Network 8.3.32)

### DIFF
--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -250,13 +250,13 @@ func resourceNetwork() *schema.Resource {
 			},
 
 			// Deprecated from paultyng/go-unifi - UnifiVersion = "7.4.162"
-			// "internet_access_enabled": {
-			// 	Description: "Specifies whether this network should be allowed to access the internet or not.",
-			// 	Type:        schema.TypeBool,
-			// 	Optional:    true,
-			// 	Default:     true,
-			// },
-
+			// Undeprecated - feature is still present in UnifiVersion = "8.3.32".
+			"internet_access_enabled": {
+				Description: "Specifies whether this network should be allowed to access the internet or not.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
 			"intra_network_access_enabled": {
 				Description: "Specifies whether this network should be allowed to access other local networks or not.",
 				Type:        schema.TypeBool,


### PR DESCRIPTION
It seems that this feature is marked as deprecated, however can't seem to find this anywhere and it's still present in v8.3.32. 
![2024-10-17_18:36:42_663x389_scrot](https://github.com/user-attachments/assets/e7616f1e-7e60-4306-a9b2-b060059f898a)
